### PR TITLE
feat: pre, postrun hooks now have access to the current command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2023-11-24
+
+### Changed
+* changed `HookBefore` and `HookAfter` to have access to the command object that is about to be / has been executed.
+
+
 ## [1.0.2] - 2023-11-24
 
 ### Fixed


### PR DESCRIPTION
User defined hooks now have access to the cobra command object they're being executed upon